### PR TITLE
⬆ Upgraded most packages allowing for 🐘 PHP 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,20 +17,21 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || 8.0",
         "ext-json": "*",
         "ext-pdo": "*",
-        "doctrine/dbal": "^2.10.3",
-        "illuminate/database": "^5.8.36",
-        "league/climate": "^3.5.2",
-        "php-di/php-di": "^6.2.2",
+        "doctrine/dbal": "^3.0.0",
+        "illuminate/database": "^v8.18.1",
+        "league/climate": "^3.6.0",
+        "php-di/php-di": "^6.3.0",
         "respect/validation": "^2.1.0",
-        "slim/psr7": "^0.3.0",
-        "slim/slim": "^4.5.0",
-        "vlucas/phpdotenv": "^3.6.7"
+        "slim/psr7": "^1.3.0",
+        "slim/slim": "^4.7.1",
+        "symfony/console": "^5.2.0",
+        "vlucas/phpdotenv": "^v3.6.7"
     },
     "require-dev": {
-        "consolidation/robo": "1.4.9",
+        "consolidation/robo": "2.2.1",
         "phpunit/phpunit": "^8.5.8"
     },
     "autoload": {


### PR DESCRIPTION
Use the `--ignore-platform-reqs` :black_flag: flag to start using PHP 8:

 `composer update --ignore-platform-reqs`