### PR TITLE
Major Refactor 🚧 of index.php and DI handling

### DIFF
--- a/app/Main/App.php
+++ b/app/Main/App.php
@@ -3,12 +3,7 @@ declare(strict_types=1);
 
 namespace Willow\Main;
 
-use DI\ContainerBuilder;
-use DI\DependencyException;
-use DI\NotFoundException;
-use Exception;
-use Illuminate\Database\Capsule\Manager as Capsule;
-
+use Psr\Container\ContainerInterface;
 use Slim\Factory\AppFactory;
 use Willow\Middleware\RegisterRouteControllers;
 use Willow\Middleware\ResponseBodyFactory;
@@ -16,50 +11,30 @@ use Willow\Middleware\ValidateRequest;
 
 class App
 {
-    protected static Capsule $capsule;
-
     /**
      * App constructor.
-     * @param bool $run
-     * @throws DependencyException
-     * @throws NotFoundException
-     * @throws Exception
+     * @param ContainerInterface $container
      */
-    public function __construct(bool $run = true)
+    public function __construct(ContainerInterface $container)
     {
-        // Set up Dependency Injection
-        $builder = new ContainerBuilder();
-        foreach (glob(__DIR__ . '/../../config/*.php') as $definitions) {
-            // Skip the _env.php file for the definitions as this was required already in public/index.php
-            if (!str_contains($definitions, '_env.php')) {
-                $builder->addDefinitions(realpath($definitions));
-            }
-        }
-
         // Get an instance of Slim\App
-        AppFactory::setContainer($builder->build());
+        AppFactory::setContainer($container);
         $app = AppFactory::create();
 
         // Add all the needed middleware
         $app->addRoutingMiddleware();
         $app->addBodyParsingMiddleware();
         $app->addErrorMiddleware(
-            getenv('DISPLAY_ERROR_DETAILS') === 'true',
+            $container->get('ENV')['DISPLAY_ERROR_DETAILS'] === 'true',
             true,
             true
         );
-
-        // Establish an instance of the Illuminate database capsule
-        self::$capsule = $app->getContainer()->get(Capsule::class);
 
         // Register the v1 group and add the middleware to the group.
         $app->group('/v1', RegisterRouteControllers::class)
             ->add(ValidateRequest::class) // Add middleware that validates the overall request.
             ->add(ResponseBodyFactory::class); // Add ResponseBody as a Request attribute
 
-        // Run will be true unless we are doing a unit test.
-        if ($run) {
-            $app->run();
-        }
+        $app->run();
     }
 }

--- a/config/_env.php
+++ b/config/_env.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 use Dotenv\Dotenv;
 
 $dotEnv = Dotenv::createImmutable(__DIR__ . '/../');
-$dotEnv->load();
-$dotEnv->required(
-    [
-        'DB_HOST',
-        'DB_PORT',
-        'DB_NAME',
-        'DB_USER',
-        'DB_PASSWORD',
-        'DISPLAY_ERROR_DETAILS'
-    ]
-);
+$env = $dotEnv->load();
+$dotEnv->required([
+    'DB_HOST',
+    'DB_PORT',
+    'DB_NAME',
+    'DB_USER',
+    'DB_PASSWORD',
+    'DISPLAY_ERROR_DETAILS'
+])->notEmpty();
+$dotEnv->required('DISPLAY_ERROR_DETAILS')->allowedValues(['true', 'false']);
+return  ['ENV' => $env];

--- a/config/db.php
+++ b/config/db.php
@@ -1,19 +1,20 @@
 <?php
 declare(strict_types=1);
 
-use Illuminate\Database\Capsule\Manager as Capsule;
+use Psr\Container\ContainerInterface;
+use Illuminate\Database\Capsule\Manager;
 
 return [
-    Capsule::class => function () {
-        $eloquent = new Capsule;
+    'Eloquent' => function(ContainerInterface $c) {
+        $eloquent = new Manager;
 
         $eloquent->addConnection([
-            'driver'    => getenv('DB_DRIVER') ?? 'mysql',
-            'host'      => getenv('DB_HOST'),
-            'port'      => getenv('DB_PORT') ?? '',
-            'database'  => getenv('DB_NAME'),
-            'username'  => getenv('DB_USER'),
-            'password'  => getenv('DB_PASSWORD'),
+            'driver'    => 'mysql',
+            'host'      => $c->get('ENV')['DB_HOST'],
+            'port'      => $c->get('ENV')['DB_PORT'],
+            'database'  => $c->get('ENV')['DB_NAME'],
+            'username'  => $c->get('ENV')['DB_USER'],
+            'password'  => $c->get('ENV')['DB_PASSWORD'],
             'charset'   => 'utf8',
             'collation' => 'utf8_unicode_ci',
             'prefix'    => ''

--- a/public/index.php
+++ b/public/index.php
@@ -1,60 +1,62 @@
 <?php
 declare(strict_types=1);
 
+use DI\ContainerBuilder;
+use League\CLImate\CLImate;
 use Willow\Main\App;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-// Does the .env file exist?
-if (file_exists(__DIR__ . '/../.env')) {
-    // Set the environment variables from the .env file
-    require_once __DIR__ . '/../config/_env.php';
-
-    // Is Willow handling CORS?
-    if (getenv('CORS') === 'true') {
-        $requestMethod = $_SERVER['REQUEST_METHOD'];
-
-        // Is this a pre-flight request (the request method is OPTIONS)? Then start output buffering.
-        if ($requestMethod === 'OPTIONS') {
-            ob_start();
-        }
-
-        // Allow for all origins and credentials. Also allow GET, POST, PATCH, and OPTIONS request verbs
-        header('Access-Control-Allow-Origin: *');
-        header('Access-Control-Allow-Credentials: true');
-        header('Access-Control-Allow-Headers: Access-Control-Allow-Headers, Origin,Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers');
-        header('Access-Control-Allow-Methods: GET, POST, PATCH, OPTIONS, DELETE');
-
-        // If this is a pre-flight request (the request method is OPTIONS)? Then flush the output buffer and exit.
-        if ($requestMethod === 'OPTIONS') {
-            ob_end_flush();
-            exit();
-        }
-    }
-} else {
-    // Output to STDERR that the .env file is missing.
-    $stdErr = fopen('php://stderr', 'b');
-    fwrite($stdErr, 'WARNING: The .env file is missing' . PHP_EOL);
-    fclose($stdErr);
-    ob_start();
-    echo 'The .env file is missing';
-    ob_end_flush();
-    exit();
-}
-
-// Launch the app
 try {
-    new App();
-} catch (Throwable $throwable) {
-    // Output to STDERR the exception error message.
-    $stdErr = fopen('php://stderr', 'b');
-    fwrite($stdErr, $throwable->getMessage() . PHP_EOL);
-    fclose($stdErr);
+    // We're always handling CORS so we check the request method up front for OPTIONS and short circuit Slim
+    $requestMethod = $_SERVER['REQUEST_METHOD'];
 
-    ob_start();
-    echo 'Message: ' . $throwable->getMessage() . ' --- ';
-    echo 'File: ' . $throwable->getFile() . ' --- ';
-    echo 'Line: ' . $throwable->getLine();
-    ob_end_flush();
+    // Is this a pre-flight request (the request method is OPTIONS)? Then start output buffering.
+    if ($requestMethod === 'OPTIONS') {
+        ob_start();
+    }
+
+    // Allow for all origins and credentials. Also allow GET, POST, PATCH, OPTIONS, and DELETE request verbs
+    header('Access-Control-Allow-Origin: *');
+    header('Access-Control-Allow-Credentials: true');
+    header('Access-Control-Allow-Headers: Access-Control-Allow-Headers, Origin,Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers');
+    header('Access-Control-Allow-Methods: GET, POST, PATCH, OPTIONS, DELETE');
+
+    // If this is a pre-flight request (the request method is OPTIONS)? Then flush the output buffer and exit.
+    if ($requestMethod === 'OPTIONS') {
+        ob_end_flush();
+        exit();
+    }
+
+    // Establish DI
+    $builder = new ContainerBuilder();
+    $builder
+        ->addDefinitions(__DIR__ . '/../config/_env.php')
+        ->addDefinitions(__DIR__ . '/../config/db.php');
+    $container = $builder->build();
+} catch (Throwable $throwable) {
+    // See: https://github.com/krakjoe/pthreads/issues/806
+    if (!defined('STDOUT')) {
+        define('STDOUT', fopen('php://stdout', 'wb'));
+    }
+
+    if (!defined('STDERR')) {
+        define('STDERR', fopen('php://stderr', 'wb'));
+    }
+
+    $cli = new CLImate();
+    $cli->br(2);
+    $cli->backgroundLightYellow()->red()->border('*', 79);
+    $cli->backgroundLightYellow()->red()->inline('Message: ')->white($throwable->getMessage());
+    $cli->backgroundLightYellow()->red()->inline('File: ')->white($throwable->getFile());
+    $cli->backgroundLightYellow()->red()->inline('Line: ')->white((string)$throwable->getLine());
+    $cli->backgroundLightYellow()->red()->border('*', 79);
+    $cli->br(2);
     exit();
 }
+
+// Instantiate the Eloquent ORM
+$container->get('Eloquent');
+
+// Launch the App
+new App($container);


### PR DESCRIPTION
- DI is established up front with the container being passed into the `App()`
- DI directly adds _env.php and db.php
- _env.php is now loaded via DI with 'ENV' as an array:
  - e.g. `$container->get('ENV')['DB_PASSWORD']`
- Consolidated preflight error handling
- Preflight error output uses Climate for syntax highlighting.
- Removed all `getenv()` calls as these are not thread safe and use DI `'ENV'` arrays instead.