### PR TITLE
Prevent adding dupes for Resident on update

### DIFF
--- a/app/Models/Resident.php
+++ b/app/Models/Resident.php
@@ -44,7 +44,7 @@ class Resident extends ModelBase
      * Override Notes to null if empty string
      * @param string|null $value
      */
-    public function setNotesAttribute(?string $value)
+    final public function setNotesAttribute(?string $value): void
     {
         if (empty($value)) {
             $this->attributes['Notes'] = null;


### PR DESCRIPTION
- Logic to restore a trashed :wastebasket: record **ONLY** for _new_ records implemented in ResidentPostAction.php
- Minor code change in Resident.php model adding final 
- Also See https://github.com/RyanNerd/rxchart-web/issues/126